### PR TITLE
Fix API route test mocks

### DIFF
--- a/app/api/analyze/__tests__/route.test.ts
+++ b/app/api/analyze/__tests__/route.test.ts
@@ -21,7 +21,7 @@ describe('/api/analyze', () => {
   it('should return 401 if the token is invalid', async () => {
     const supabase = {
       auth: {
-        getUser: jest.fn().mockResolvedValue({ error: new Error('Invalid token'), user: null }),
+        getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: new Error('Invalid token') }),
       },
     };
     (createClient as jest.Mock).mockReturnValue(supabase);
@@ -40,7 +40,7 @@ describe('/api/analyze', () => {
   it('should return 400 if the request body is invalid', async () => {
     const supabase = {
       auth: {
-        getUser: jest.fn().mockResolvedValue({ error: null, user: { id: '123' } }),
+        getUser: jest.fn().mockResolvedValue({ data: { user: { id: '123' } }, error: null }),
       },
     };
     (createClient as jest.Mock).mockReturnValue(supabase);

--- a/app/api/user-api-keys/[id]/__tests__/route.test.ts
+++ b/app/api/user-api-keys/[id]/__tests__/route.test.ts
@@ -22,7 +22,7 @@ describe('/api/user-api-keys/[id]', () => {
     it('should return 401 if the token is invalid', async () => {
       const supabase = {
         auth: {
-          getUser: jest.fn().mockResolvedValue({ error: new Error('Invalid token'), user: null }),
+          getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: new Error('Invalid token') }),
         },
       };
       (createClient as jest.Mock).mockReturnValue(supabase);
@@ -41,7 +41,7 @@ describe('/api/user-api-keys/[id]', () => {
     it('should return 400 if the request body is invalid', async () => {
       const supabase = {
         auth: {
-          getUser: jest.fn().mockResolvedValue({ error: null, user: { id: '123' } }),
+          getUser: jest.fn().mockResolvedValue({ data: { user: { id: '123' } }, error: null }),
         },
       };
       (createClient as jest.Mock).mockReturnValue(supabase);
@@ -51,7 +51,7 @@ describe('/api/user-api-keys/[id]', () => {
         headers: new Headers({
           Authorization: 'Bearer valid-token',
         }),
-        body: JSON.stringify({}),
+        body: JSON.stringify({ nickname: 123 }),
       });
 
       const response = await PUT(request, { params: { id: '123' } });
@@ -73,7 +73,7 @@ describe('/api/user-api-keys/[id]', () => {
     it('should return 401 if the token is invalid', async () => {
       const supabase = {
         auth: {
-          getUser: jest.fn().mockResolvedValue({ error: new Error('Invalid token'), user: null }),
+          getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: new Error('Invalid token') }),
         },
       };
       (createClient as jest.Mock).mockReturnValue(supabase);

--- a/app/api/user-api-keys/__tests__/route.test.ts
+++ b/app/api/user-api-keys/__tests__/route.test.ts
@@ -20,11 +20,11 @@ describe('/api/user-api-keys', () => {
     });
 
     it('should return 401 if the token is invalid', async () => {
-      const supabase = {
-        auth: {
-          getUser: jest.fn().mockResolvedValue({ error: new Error('Invalid token'), user: null }),
-        },
-      };
+    const supabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: new Error('Invalid token') }),
+      },
+    };
       (createClient as jest.Mock).mockReturnValue(supabase);
 
       const request = new NextRequest('http://localhost/api/user-api-keys', {
@@ -39,11 +39,11 @@ describe('/api/user-api-keys', () => {
     });
 
     it('should return 400 if the request body is invalid', async () => {
-      const supabase = {
-        auth: {
-          getUser: jest.fn().mockResolvedValue({ error: null, user: { id: '123' } }),
-        },
-      };
+    const supabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({ data: { user: { id: '123' } }, error: null }),
+      },
+    };
       (createClient as jest.Mock).mockReturnValue(supabase);
 
       const request = new NextRequest('http://localhost/api/user-api-keys', {
@@ -71,11 +71,11 @@ describe('/api/user-api-keys', () => {
     });
 
     it('should return 401 if the token is invalid', async () => {
-      const supabase = {
-        auth: {
-          getUser: jest.fn().mockResolvedValue({ error: new Error('Invalid token'), user: null }),
-        },
-      };
+    const supabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: new Error('Invalid token') }),
+      },
+    };
       (createClient as jest.Mock).mockReturnValue(supabase);
 
       const request = new NextRequest('http://localhost/api/user-api-keys', {


### PR DESCRIPTION
## Summary
- update supabase auth mocks to match `{ data, error }` response
- adjust invalid body in API key update test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68794bdde3088332a2bbf6a980cca69b