### PR TITLE
Fix API route tests and validation

### DIFF
--- a/app/api/analyze/__tests__/route.test.ts
+++ b/app/api/analyze/__tests__/route.test.ts
@@ -21,7 +21,10 @@ describe('/api/analyze', () => {
   it('should return 401 if the token is invalid', async () => {
     const supabase = {
       auth: {
-        getUser: jest.fn().mockResolvedValue({ error: new Error('Invalid token'), user: null }),
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+          error: new Error('Invalid token'),
+        }),
       },
     };
     (createClient as jest.Mock).mockReturnValue(supabase);
@@ -40,7 +43,10 @@ describe('/api/analyze', () => {
   it('should return 400 if the request body is invalid', async () => {
     const supabase = {
       auth: {
-        getUser: jest.fn().mockResolvedValue({ error: null, user: { id: '123' } }),
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: '123' } },
+          error: null,
+        }),
       },
     };
     (createClient as jest.Mock).mockReturnValue(supabase);

--- a/app/api/user-api-keys/[id]/__tests__/route.test.ts
+++ b/app/api/user-api-keys/[id]/__tests__/route.test.ts
@@ -22,7 +22,10 @@ describe('/api/user-api-keys/[id]', () => {
     it('should return 401 if the token is invalid', async () => {
       const supabase = {
         auth: {
-          getUser: jest.fn().mockResolvedValue({ error: new Error('Invalid token'), user: null }),
+          getUser: jest.fn().mockResolvedValue({
+            data: { user: null },
+            error: new Error('Invalid token'),
+          }),
         },
       };
       (createClient as jest.Mock).mockReturnValue(supabase);
@@ -41,7 +44,10 @@ describe('/api/user-api-keys/[id]', () => {
     it('should return 400 if the request body is invalid', async () => {
       const supabase = {
         auth: {
-          getUser: jest.fn().mockResolvedValue({ error: null, user: { id: '123' } }),
+          getUser: jest.fn().mockResolvedValue({
+            data: { user: { id: '123' } },
+            error: null,
+          }),
         },
       };
       (createClient as jest.Mock).mockReturnValue(supabase);
@@ -73,7 +79,10 @@ describe('/api/user-api-keys/[id]', () => {
     it('should return 401 if the token is invalid', async () => {
       const supabase = {
         auth: {
-          getUser: jest.fn().mockResolvedValue({ error: new Error('Invalid token'), user: null }),
+          getUser: jest.fn().mockResolvedValue({
+            data: { user: null },
+            error: new Error('Invalid token'),
+          }),
         },
       };
       (createClient as jest.Mock).mockReturnValue(supabase);

--- a/app/api/user-api-keys/__tests__/route.test.ts
+++ b/app/api/user-api-keys/__tests__/route.test.ts
@@ -22,7 +22,10 @@ describe('/api/user-api-keys', () => {
     it('should return 401 if the token is invalid', async () => {
       const supabase = {
         auth: {
-          getUser: jest.fn().mockResolvedValue({ error: new Error('Invalid token'), user: null }),
+          getUser: jest.fn().mockResolvedValue({
+            data: { user: null },
+            error: new Error('Invalid token'),
+          }),
         },
       };
       (createClient as jest.Mock).mockReturnValue(supabase);
@@ -41,7 +44,10 @@ describe('/api/user-api-keys', () => {
     it('should return 400 if the request body is invalid', async () => {
       const supabase = {
         auth: {
-          getUser: jest.fn().mockResolvedValue({ error: null, user: { id: '123' } }),
+          getUser: jest.fn().mockResolvedValue({
+            data: { user: { id: '123' } },
+            error: null,
+          }),
         },
       };
       (createClient as jest.Mock).mockReturnValue(supabase);
@@ -73,7 +79,10 @@ describe('/api/user-api-keys', () => {
     it('should return 401 if the token is invalid', async () => {
       const supabase = {
         auth: {
-          getUser: jest.fn().mockResolvedValue({ error: new Error('Invalid token'), user: null }),
+          getUser: jest.fn().mockResolvedValue({
+            data: { user: null },
+            error: new Error('Invalid token'),
+          }),
         },
       };
       (createClient as jest.Mock).mockReturnValue(supabase);

--- a/lib/api/validation.ts
+++ b/lib/api/validation.ts
@@ -18,7 +18,11 @@ export const addApiKeyRequestSchema = z.object({
   preferredModel: z.string().optional(),
 });
 
-export const updateApiKeyRequestSchema = z.object({
-  nickname: z.string().optional(),
-  preferredModel: z.string().optional(),
-});
+export const updateApiKeyRequestSchema = z
+  .object({
+    nickname: z.string().optional(),
+    preferredModel: z.string().optional(),
+  })
+  .refine((data) => data.nickname !== undefined || data.preferredModel !== undefined, {
+    message: 'At least one field must be provided',
+  });


### PR DESCRIPTION
## Summary
- correct mock Supabase responses to include `data` field
- require a property in `updateApiKeyRequestSchema`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68794bda133c833287575d9aaa192f29