### PR TITLE
Improve markdown table handling and Word export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.445.0",
         "mammoth": "^1.9.1",
+        "marked": "^16.1.0",
         "next": "15.0.3",
         "pdf2json": "^3.1.6",
         "postcss": "^8.4.49",
@@ -9964,6 +9965,18 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.0.tgz",
+      "integrity": "sha512-Me7BNa1aqrxVinDnFfvCgHh2yHvLbFvILBs899MhuBpbE5VPzpSqv7alaESfkqkgc9JNvUGH4gqwZeOzLnY8Jg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.445.0",
     "mammoth": "^1.9.1",
+    "marked": "^16.1.0",
     "next": "15.0.3",
     "pdf2json": "^3.1.6",
     "postcss": "^8.4.49",


### PR DESCRIPTION
## Summary
- use `marked` for markdown parsing
- export Word docs using `html-docx-js`
- add `marked` dependency

## Testing
- `npm run type-check`
- `npm test`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_687996c017d48332ba3a73aacc63c84f