### PR TITLE
Add analyze page workflow documentation

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -17,6 +17,7 @@
 - [DESIGN_SYSTEM.md](#design_system-md) - UI/UX design guidelines and component library
 - [ADMIN_PAGE_FLOW.md](#admin_page_flow-md) - Admin dashboard workflow
 - [API_KEY_PAGE.md](#api_key_page-md) - API key workflow for each user type
+- [ANALYZE_PAGE_FLOW.md](#analyze_page_flow-md) - Analyze page workflow
 - [DOCUMENTATION_INDEX.md](#documentation_index-md) - This file
 
 ---
@@ -71,6 +72,11 @@
 - **Purpose**: Explain API key management workflow for each user type
 - **Contains**: Mermaid diagram of page logic and brief behavior overview
 - **Use Case**: For contributors to understand access controls and API flows when updating key management features.
+
+#### **ANALYZE_PAGE_FLOW.md**
+- **Purpose**: Illustrates the Analyze page workflow for each user type
+- **Contains**: Mermaid diagram of authentication and key-selection logic
+- **Use Case**: For developers and stakeholders to understand user interactions
 
 #### **DOCUMENTATION_INDEX.md**
 - **Purpose**: Navigation and reference system

--- a/docs/ANALYZE_PAGE_FLOW.md
+++ b/docs/ANALYZE_PAGE_FLOW.md
@@ -1,0 +1,42 @@
+# Analyze Page Workflow
+
+This document illustrates how different user types interact with the Analyze page. All users must sign in before accessing `/dashboard/analyze`.
+
+```mermaid
+flowchart TD
+    Start["Open /dashboard/analyze"] --> Auth{Authenticated?}
+    Auth -- "No" --> Login["Redirect to login"]
+    Auth -- "Yes" --> Role{Access level}
+
+    subgraph Basic
+        Role -- "basic" --> B1["Select company & type"]
+        B1 --> BKey{Key source}
+        BKey -- "Owner or Temporary" --> BRun["Run analysis"]
+    end
+
+    subgraph Advanced
+        Role -- "advanced" --> A1["Select company & type"]
+        A1 --> AKey{Key source}
+        AKey -- "Owner" --> ARun["Run analysis"]
+        AKey -- "Saved" --> ARun
+        AKey -- "Temporary" --> ARun
+    end
+
+    subgraph Admin
+        Role -- "admin" --> C1["Select company & type"]
+        C1 --> CKey{Key source}
+        CKey -- "Owner" --> CRun["Run analysis"]
+        CKey -- "Saved" --> CRun
+        CKey -- "Temporary" --> CRun
+    end
+
+    BRun --> Result["View result"]
+    ARun --> Result
+    CRun --> Result
+```
+
+**User Types**
+
+- **Basic** – Uses admin-assigned keys or a temporary key. Cannot save personal keys.
+- **Advanced** – May save personal API keys in addition to any assigned by an admin.
+- **Admin** – Full privileges, including managing keys and system settings.


### PR DESCRIPTION
## Summary
- document how the Analyze page behaves for each user type
- index the new file in the documentation list

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run type-check`
- `npm test` *(fails: 2 failing tests)*
- `npm run build` *(fails: Missing Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_687abe39f89c83328281138b1f3c3609